### PR TITLE
Detection of small SV using split reads

### DIFF
--- a/extract_variants/extract_variants.py
+++ b/extract_variants/extract_variants.py
@@ -111,7 +111,7 @@ def main(args):
         try:  
             pysam.sort(output_dir+".bam","-o" + output_dir+".sorted.bam")
         except:
-            pysam.sort(output_dir+".bam",output_dir+".sorted.bam")
+            pysam.sort(output_dir+".bam",output_dir+".sorted")
         os.rename(output_dir+".sorted.bam", output_dir+".bam")
     return()
 

--- a/extract_variants/extract_variants.py
+++ b/extract_variants/extract_variants.py
@@ -1,0 +1,128 @@
+import pysam
+import argparse
+import os
+import sys
+
+def get_regions(vcf,padding):
+    variants=[]
+    for line in open(vcf):
+        if line[0] == "#":
+            continue
+        if "WINA" in line and "WINB" in line:
+            a=line.split("WINA=")[-1].split(";")[0].split(",")
+            a[0]=int(a[0])-padding
+            if a[0] < 0:
+                a[0] =0
+                
+            a[1]=int(a[1])+padding
+            chra=line.split("CHRA=")[-1].split(";")[0]
+        
+            b=line.split("WINB=")[-1].split(";")[0].split(",")
+            b[0]=int(b[0])-padding
+            if b[0] < 0:
+                b[0] =0
+            b[1]=int(b[1])+padding
+            chrb=line.split("CHRB=")[-1].split(";")[0]
+            
+            #the regions should not overlap
+            if(chrb == chra and b[0] <= a[1]):
+                b[0] = a[1]+1
+            variant={"ID":line.split("\t")[2],"startA":a[0],"endA":a[1],"chrA":chra,"startB":b[0],"endB":b[1],"chrB":chrb}
+            variants.append(variant)
+    
+    return variants
+    
+def get_tab(tab,padding):
+    variants=[]
+    i=0
+    for line in open(tab):
+        if line[0] == "#":
+            continue
+        content=line.strip().split("\t");
+        if len(content) >= 6:
+            a=[ content[1],content[2] ]
+            a[0]=int(a[0])-padding
+            if a[0] < 0:
+                a[0] =0
+                
+            a[1]=int(a[1])+padding
+            chra=content[0]
+        
+            b=[content[4],content[5]]
+            b[0]=int(b[0])-padding
+            if b[0] < 0:
+                b[0] =0
+            b[1]=int(b[1])+padding
+            chrb=content[3]
+            
+            #the regions should not overlap
+            if(chrb == chra and b[0] <= a[1]):
+                b[0] = a[1]+1
+            variant={"ID":"Region_"+str(i),"startA":a[0],"endA":a[1],"chrA":chra,"startB":b[0],"endB":b[1],"chrB":chrb}
+            variants.append(variant)
+            i +=1
+        else:
+            a=[ content[1],int(content[2]) ]
+            a[0]=int(a[0])-padding
+            if a[0] < 0:
+                a[0] =0
+                
+            a[1] += padding
+            region="Region_"+str(i)
+            if len(content) > 3:
+                region += "_" + content[3]
+                
+            variant={"ID":region,"startA":a[0],"endA":a[1],"chrA":content[0],"startB":-1,"endB":-1,"chrB":-1}
+            variants.append(variant)
+            i +=1
+            
+    return variants
+def main(args):
+    if not os.path.exists(args.working_dir) and not args.working_dir == "":
+        os.makedirs(args.working_dir)
+    alignmentFile = pysam.AlignmentFile(args.bam, "rb") 
+    if args.vcf:
+        variants=get_regions(args.vcf,args.padding)
+    elif args.tab:
+        variants=get_tab(args.tab,args.padding)
+    else:
+        print("Error: --vcf or --tab is required")
+        sys.exit()
+    #print the regions to a bam file
+    print "please remember these numbers!"
+    for variant in variants:
+        output_dir=os.path.join(args.working_dir,variant["ID"])
+        with pysam.AlignmentFile(output_dir+".bam", "wb", header=alignmentFile.header) as outf:
+            if not variant["chrB"] == -1 and not variant["startB"] == -1:
+                print("{}|{}:{}-{}|{}:{}-{}".format(variant["ID"],variant["chrA"], variant["startA"], variant["endA"],variant["chrB"], variant["startB"], variant["endB"]))
+            else:
+                print("{}|{}:{}-{}".format(variant["ID"],variant["chrA"], variant["startA"], variant["endA"]))
+            iter = alignmentFile.fetch(variant["chrA"], variant["startA"], variant["endA"])
+            for x in iter:
+                outf.write(x)
+                
+            if not variant["chrB"] == -1 and not variant["startB"] == -1:
+                iter = alignmentFile.fetch(variant["chrB"], variant["startB"], variant["endB"])
+                for x in iter:
+                    outf.write(x)
+                    
+    #sort the file   
+    for variant in variants:
+        try:  
+            pysam.sort(output_dir+".bam","-o" + output_dir+".sorted.bam")
+        except:
+            pysam.sort(output_dir+".bam",output_dir+".sorted.bam")
+        os.rename(output_dir+".sorted.bam", output_dir+".bam")
+    return()
+
+
+parser = argparse.ArgumentParser("""extracts the alignments of structural variants called by TIDDIT""")
+parser.add_argument('--vcf',type=str,help="the path to the TIDDIT vcf file")
+parser.add_argument('--tab',type=str,help="the path to to a tab file(used instead of vcf)")
+parser.add_argument('--bam',type=str,required = True,help="the path to the bam file")
+parser.add_argument('--working_dir',type=str,default="",help="path to the output dir(default is pwd)")
+parser.add_argument('--padding',type=int,default=150,help="extend the region by this number of bases(default is 150)")
+
+args, unknown = parser.parse_known_args()
+
+main(args)

--- a/src/TIDDIT.cpp
+++ b/src/TIDDIT.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 	//MAIN VARIABLE
 
 	bool outtie 				    = true;	 // library orientation
-	uint32_t minimumSupportingPairs = 4;
+	uint32_t minimumSupportingPairs = 8;
 	int min_insert				    = 100;      // min insert size
 	int max_insert				    = 100000;  // max insert size
 	int minimum_mapping_quality		=10;
@@ -70,9 +70,9 @@ int main(int argc, char **argv) {
 	vm["--plody"]="";
 	
 	string sv_help ="\nUsage: TIDDIT --sv -b inputfile [-o prefix] \nOther options\n";
-	sv_help +="\t--insert\tpaired reads maximum allowed insert size. Pairs aligning on the same chr at a distance higher than this are considered candidates for SV (if not specified default=2std + mean_insert_size)\n";
+	sv_help +="\t--insert\tpaired reads maximum allowed insert size. Pairs aligning on the same chr at a distance higher than this are considered candidates for SV (if not specified default=3std + mean_insert_size)\n";
 	sv_help +="\t--orientation\texpected reads orientations, possible values \"innie\" (-> <-) or \"outtie\" (<- ->). Default: major orientation within the dataset\n";
-	sv_help +="\t-p\tMinimum number of supporting pairs in order to call a variation event (default 4)\n";
+	sv_help +="\t-p\tMinimum number of supporting pairs in order to call a variation event (default 8)\n";
 	sv_help +="\t-q\tMinimum mapping quality to consider an alignment (default 10)\n";
 	sv_help +="\t-c\taverage coverage, (default= computed from the bam file)\n";
 	sv_help +="\t--plody\tthe number of sets of chromosomes,(default = 2)\n";
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
 		
 		meanInsert = library.insertMean;
 		insertStd  = library.insertStd;
-		max_insert=meanInsert+2.5*insertStd;
+		max_insert=meanInsert+3*insertStd;
 		if(vm["--insert"] != ""){
 			max_insert  = convert_str( vm["--insert"], "--insert");
 		}else{

--- a/src/common.h
+++ b/src/common.h
@@ -263,6 +263,13 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
 			mappedReads ++;
 			mappedReadsLength += al.Length;
 		}
+		
+		vector <int > clipSizes;
+		vector< int > readPositions;
+		vector<int> genomePos;
+		if ( al.GetSoftClips(clipSizes,readPositions,genomePos) ){
+			splitReads += 1;
+		}
 
         //calculate the coverage in bins of size 400 bases
         calculateCoverage -> bin(al);
@@ -325,10 +332,8 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
 	cout << "\t total reads number "	<< reads << "\n";
 	cout << "\t total mapped reads " 	<< mappedReads << "\n";
 	cout << "\t total unmapped reads " 	<< unmappedReads << "\n";
-	cout << "\t proper pairs " 	       	<< matedReads << "\n";
 	cout << "\t split reads "               << splitReads << "\n";
-	cout << "\t wrong distance "		<< wrongDistanceReads << "\n";
-	cout << "\t zero quality reads " 	<< lowQualityReads << "\n";
+	cout << "\t low quality reads " 	<< lowQualityReads << "\n";
 	cout << "\t wrongly contig "		<< matedDifferentContig << "\n";
 	cout << "\t singletons " 		<< singletonReads << "\n";
 

--- a/src/common.h
+++ b/src/common.h
@@ -65,6 +65,7 @@ public:
 	int binEnd;
 	int currentChr;
 	vector< vector<unsigned int> > coverageStructure;
+	vector< vector< vector<unsigned int> > >qualityStructure;
 	map<unsigned int,string> position2contig;
 	map<string,unsigned int> contig2position;
 	vector<int> contigLength;

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -841,7 +841,7 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 		ss << ";QUALA=" << discordantPairStatistics["qualityA"] << ";QUALB=" << discordantPairStatistics["qualityB"];
 		if(discordantPairStatistics["expected_links"] != 0){
 			ss << ";EL="  << discordantPairStatistics["expected_links"] << ";RATIO=" <<  (float)discordantPairStatistics["links_event"]/(float)discordantPairStatistics["expected_links"];
-			filter=filterFunction((float)discordantPairStatistics["links_event"]/(float)discordantPairStatistics["expected_links"],discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage, discordantPairStatistics["windowA_start"],discordantPairStatistics["windowB_start"],discordantPairStatistics["chrA"],discordantPairStatistics["chrB"]);	
+			filter=filterFunction((float)discordantPairStatistics["links_event"]/(float)discordantPairStatistics["expected_links"],discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage, discordantPairStatistics["windowA_end"],discordantPairStatistics["windowB_start"],discordantPairStatistics["chrA"],discordantPairStatistics["chrB"]);	
 	
 		}else{
 			ss << ";EL="  << discordantPairStatistics["expected_links"] << ";RATIO=-1";
@@ -876,7 +876,7 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 		}
 
 		double RATIO =1;
-		int E_links= splitReadStatistics["coverage_start"];
+		int E_links= splitReadStatistics["coverage_start"]/(double(this -> ploidy));
 		if(E_links > 0){
 			RATIO=this -> ploidy*double(splitReadStatistics["split_reads"])/double(E_links);
 		}

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -869,9 +869,14 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 			read2_orientation="Forward";
 		}
 
-
-		filter=filterFunction(1,splitReadStatistics["split_reads"],splitReadStatistics["links_window"],mean_insert,std_insert,splitReadStatistics["coverage_start"],splitReadStatistics["coverage_end"],meanCoverage,splitReadStatistics["start"],splitReadStatistics["end"],splitReadStatistics["chrA"],splitReadStatistics["chrB"]);
-
+		if (discordantPairStatistics["chrA"] != -1){
+			double RATIO =1;
+			if(splitReadStatistics["coverage_start"] > 0){
+				double RATIO=this -> ploidy*splitReadStatistics["split_reads"]/double(splitReadStatistics["coverage_start"]);
+			}
+			filter=filterFunction(RATIO,splitReadStatistics["split_reads"],splitReadStatistics["links_window"],mean_insert,std_insert,splitReadStatistics["coverage_start"],splitReadStatistics["coverage_end"],meanCoverage,splitReadStatistics["start"],splitReadStatistics["end"],splitReadStatistics["chrA"],splitReadStatistics["chrB"]);
+		}
+		
 		chrB= splitReadStatistics["chrB"];
 		chrA = splitReadStatistics["chrA"];
 		posA= splitReadStatistics["start"];

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -269,18 +269,31 @@ void Window::insertRead(BamAlignment alignment) {
 	  		if(splitPos < currrentAlignmentPos){
 				continue;
 			}
-
-			//determine the "pair" orientation
-			if( alignment.IsReverseStrand() == false and SA_elements[2] == "-"  ){
-				this -> pairOrientation = 0;
-			}else if( alignment.IsReverseStrand() == false and SA_elements[2] == "+" ){
-				this -> pairOrientation = 1;
-			}else if( alignment.IsReverseStrand() == true and SA_elements[2] == "-" ){
-				this -> pairOrientation =2;
+			
+			if(alignment.IsFirstMate() ){	
+				//determine the "pair" orientation
+				if( alignment.IsReverseStrand() == false and SA_elements[2] == "-"  ){
+					this -> pairOrientation = 0;
+				}else if( alignment.IsReverseStrand() == false and SA_elements[2] == "+" ){
+					this -> pairOrientation = 1;
+				}else if( alignment.IsReverseStrand() == true and SA_elements[2] == "-" ){
+					this -> pairOrientation =2;
+				}else{
+					this -> pairOrientation =3;
+				}
 			}else{
-				this -> pairOrientation =3;
+				//the orientation of the mate is inverted compared to the first read
+				if( alignment.IsReverseStrand() == true and SA_elements[2] == "+"  ){
+					this -> pairOrientation = 0;
+				}else if( alignment.IsReverseStrand() == true and SA_elements[2] == "-" ){
+					this -> pairOrientation = 1;
+				}else if( alignment.IsReverseStrand() == false and SA_elements[2] == "+" ){
+					this -> pairOrientation =2;
+				}else{
+					this -> pairOrientation =3;
+				}
+			
 			}
-
 			if (eventReads[this -> pairOrientation][contigNr].size() > 0){
 				discordantDistance = currrentAlignmentPos- eventReads[this -> pairOrientation][contigNr].back().Position;
 			}

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -567,7 +567,7 @@ bool Window::computeVariations(int chr2) {
 				double coverageRealSecondWindow=computeCoverageB(chr2, startSecondWindow, stopSecondWindow, (stopSecondWindow-startSecondWindow+1) );
 				double coverageMid=0;
 				if(this -> chr == chr2){
-					double coverageMid=computeCoverageB(chr2, startchrA, stopSecondWindow, (startchrA-startSecondWindow+1) );
+					coverageMid=computeCoverageB(chr2, startchrA, stopSecondWindow, (startchrA-startSecondWindow+1) );
 				}				
 				double qualityB = computeRegionalQuality(chr2, startSecondWindow, stopSecondWindow,300);
 				double qualityA = computeRegionalQuality(this -> chr, startchrA, stopchrA,300);
@@ -577,8 +577,8 @@ bool Window::computeVariations(int chr2) {
 				int linksFromWindow=int(statisticsFirstWindow[1]);
 
 				//calculate the expected number of reads
-				int secondWindowLength=(stopSecondWindow-startSecondWindow+1);
-				int firstWindowLength=stopchrA-startchrA+1;
+				int secondWindowLength=(stopSecondWindow-startSecondWindow+1+this-> readLength);
+				int firstWindowLength=stopchrA-startchrA+1+this-> readLength;
 
 				if(estimatedDistance > firstWindowLength) {
 					estimatedDistance = estimatedDistance - firstWindowLength;
@@ -617,7 +617,7 @@ bool Window::computeVariations(int chr2) {
 				discordantPairStatistics["links_window"]=linksFromWindow;
 				discordantPairStatistics["links_chr"]=numLinksToChr2;
 				discordantPairStatistics["links_event"]=pairsFormingLink;
-				discordantPairStatistics["expected_links"]=expectedLinksInWindow;
+				discordantPairStatistics["expected_links"]=abs(expectedLinksInWindow);
 				discordantPairStatistics["qualityB"]=qualityB;
 				discordantPairStatistics["qualityA"]=qualityA;
 				//These statistics define the variants detected by split reads
@@ -821,13 +821,13 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 		ss << ";COVM=" << discordantPairStatistics["coverage_mid"];
 		ss << ";COVB=" << discordantPairStatistics["coverage_end"] << ";OA=" << read1_orientation << ";OB=" << read2_orientation;
 		ss << ";QUALA=" << discordantPairStatistics["qualityA"] << ";QUALB=" << discordantPairStatistics["qualityB"];
-		if(discordantPairStatistics["expected_links"] > 0){
+		if(discordantPairStatistics["expected_links"] != 0){
 			ss << ";EL="  << discordantPairStatistics["expected_links"] << ";RATIO=" <<  (float)discordantPairStatistics["links_event"]/(float)discordantPairStatistics["expected_links"];
 			filter=filterFunction((float)discordantPairStatistics["links_event"]/(float)discordantPairStatistics["expected_links"],discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage);	
 	
 		}else{
-			ss << ";EL="  << discordantPairStatistics["expected_links"] << ";RATIO=inf";
-				filter=filterFunction(0,discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage);	
+			ss << ";EL="  << discordantPairStatistics["expected_links"] << ";RATIO=-1";
+				filter=filterFunction(1,discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage);	
 	
 		}
 		infoField += ss.str();

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -501,7 +501,7 @@ bool Window::computeVariations(int chr2) {
 			int splitsFormingLink=0;
 			for(int j=0;j< splitReadPositions[0].size();j++){
 				if(startSecondWindow <= splitReadPositions[1][j] and splitReadPositions[1][j] <= stopSecondWindow){	
-					if(startchrA <= splitReadPositions[0][j] and splitReadPositions[1][j] <= stopchrA){
+					if(startchrA <= splitReadPositions[0][j] and splitReadPositions[0][j] <= stopchrA){
 						splitsFormingLink++;
 					}			
 				}			

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -589,6 +589,11 @@ bool Window::computeVariations(int chr2) {
 				}else{
 					estimatedDistance = 1;
 				}
+				//the pairs spanning the first and second window must have normal insert size, otherwise they are discordant
+				if(estimatedDistance + firstWindowLength < mean_insert){
+				    estimatedDistance = mean_insert - firstWindowLength;
+				}
+				
 				float expectedLinksInWindow = ExpectedLinks(firstWindowLength, secondWindowLength, estimatedDistance, mean_insert, std_insert, coverageRealFirstWindow, this -> readLength);					
 				if (expectedLinksInWindow > 10*pairsFormingLink){
 					//dont print the variant if it is pure garbage

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -432,7 +432,7 @@ bool Window::computeVariations(int chr2) {
 	queue <BamAlignment> test_queue = this-> eventReads[this -> pairOrientation][chr2];
 	
 	//transfer the positions of the split reads and discordant pairs into vectors
-	if( test_queue.size() >= minimumPairs) {
+	if( test_queue.size() >= minimumPairs) {		
 		while(test_queue.size() > 0 ){
 			discordantPairPositions[0].push_back(test_queue.front().Position);
 			discordantPairPositions[1].push_back(test_queue.front().MatePosition);
@@ -440,7 +440,7 @@ bool Window::computeVariations(int chr2) {
 		}
 		discordantPairs=true;
 	}
-	
+
 	if(this->eventSplitReads[chr2].size() > 0){
 		for (vector<BamAlignment>::iterator alnit = eventSplitReads[chr2].begin(); alnit != eventSplitReads[chr2].end(); ++alnit) {
 			string SA;
@@ -465,7 +465,6 @@ bool Window::computeVariations(int chr2) {
 					SA_elements.push_back(SA_data);
 				}
 			}	
-		
 			for(int j=0; j< SA_elements.size(); j+=6) {
 				string contig = SA_elements[j];
 				string chr2name = this -> position2contig[chr2];
@@ -506,7 +505,6 @@ bool Window::computeVariations(int chr2) {
 					}			
 				}			
 			}
-
 			vector<int> statsOnB=findLinksToChr2(eventReads[this -> pairOrientation][chr2],startchrA, stopchrA,startSecondWindow,stopSecondWindow,pairsFormingLink);
 			int numLinksToChr2=statsOnB[0];
 			int estimatedDistance=statsOnB[1];
@@ -569,14 +567,14 @@ bool Window::computeVariations(int chr2) {
 				splitReadStatistics["start"]=-1;
 				splitReadStatistics["end"]=-1;
 				splitReadStatistics["split_reads"]=splitsFormingLink;
-				discordantPairStatistics["coverage_mid"]=-1;	
+				splitReadStatistics["coverage_mid"]=-1;	
 				
 				VCFLine(discordantPairStatistics,splitReadStatistics,svType,GT,CN);
 				found = true;
-				
 			}
 		}
-	}else if(chr2 == this -> chr){
+	//we only check for intrachromosomal variants, oherwise we would detect discrodant pairs aswell
+	}else if(chr2 == this -> chr and splitReads){
 		vector<long> chr2regions= findRegionOnB( splitReadPositions[1] ,minimumPairs,this ->readLength);
 	
 		for(int i=0;i < chr2regions.size()/3;i++){

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -876,9 +876,9 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 		}
 
 		double RATIO =1;
-		int E_links= double(splitReadStatistics["coverage_start"]);
-		if(splitReadStatistics["coverage_start"] > 0){
-			double RATIO=this -> ploidy*splitReadStatistics["split_reads"]/double(splitReadStatistics["coverage_start"]);
+		int E_links= splitReadStatistics["coverage_start"];
+		if(E_links > 0){
+			RATIO=this -> ploidy*double(splitReadStatistics["split_reads"])/double(E_links);
 		}
 		filter=filterFunction(RATIO,splitReadStatistics["split_reads"],splitReadStatistics["links_window"],mean_insert,std_insert,splitReadStatistics["coverage_start"],splitReadStatistics["coverage_end"],meanCoverage,splitReadStatistics["start"],splitReadStatistics["end"],splitReadStatistics["chrA"],splitReadStatistics["chrB"]);
 		
@@ -892,11 +892,11 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 			ss << ";END=" << posB;
 		}
 		ss << ";WINA=" << splitReadStatistics["windowA_start"] << "," << splitReadStatistics["windowA_end"];
-		ss << ";WINB=" << discordantPairStatistics["windowB_start"] << "," << discordantPairStatistics["windowB_end"];
+		ss << ";WINB=" << splitReadStatistics["windowB_start"] << "," << splitReadStatistics["windowB_end"];
 		ss << ";COVA=" << splitReadStatistics["coverage_start"] << ";COVM=" << splitReadStatistics["coverage_mid"] << ";COVB=" << splitReadStatistics["coverage_end"];
 		ss <<  ";QUALA=" << splitReadStatistics["qualityA"] << ";QUALB=" << splitReadStatistics["qualityB"];
 		ss << ";OA=" << read1_orientation << ";OB=" << read2_orientation << ";LFW=" << splitReadStatistics["links_window"] ;
-		ss << ";ER=" << E_links << ";RATIO=" << RATIO << endl;
+		ss << ";ER=" << E_links << ";RATIO=" << RATIO;
 		infoField += ss.str();
 	}
 	

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -825,7 +825,10 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 		
 		ss << ";CHRA=" << position2contig[discordantPairStatistics["chrA"]] << ";WINA=" << discordantPairStatistics["windowA_start"] << "," << discordantPairStatistics["windowA_end"];
 		ss << ";CHRB=" << position2contig[discordantPairStatistics["chrB"]] << ";WINB=" << discordantPairStatistics["windowB_start"] << "," << discordantPairStatistics["windowB_end"];
-		ss << ";END=" << discordantPairStatistics["end"] << ";LFW=" << discordantPairStatistics["links_window"];
+		if(discordantPairStatistics["chrA"] == discordantPairStatistics["chrB"]){
+		ss << ";END=" << discordantPairStatistics["end"];
+		} 
+		ss << ";LFW=" << discordantPairStatistics["links_window"];
 		ss << ";LCB="  << discordantPairStatistics["links_chr"] << ";LTE=" << discordantPairStatistics["links_event"] << ";COVA=" <<  discordantPairStatistics["coverage_start"];
 		ss << ";COVM=" << discordantPairStatistics["coverage_mid"];
 		ss << ";COVB=" << discordantPairStatistics["coverage_end"] << ";OA=" << read1_orientation << ";OB=" << read2_orientation;

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -702,13 +702,13 @@ bool Window::computeVariations(int chr2) {
 			splitReadStatistics["windowB_end"]=stopSecondWindow;
 			splitReadStatistics["end"]=stopSecondWindow;
 			splitReadStatistics["split_reads"]=splitsFormingLink;
-			splitReadStatistics["coverage_mid"]=computeCoverageB(chr2,stopchrA, startSecondWindow, (startSecondWindow+1-stopchrA) );
+			splitReadStatistics["coverage_mid"]=computeCoverageB(chr2,startchrA, stopSecondWindow, (stopSecondWindow+1-startchrA) );
 			splitReadStatistics["splitOrientation"]= this -> pairOrientation;
 			splitReadStatistics["qualityA"]=computeRegionalQuality(this -> chr, startchrA, stopchrA,300);
 			splitReadStatistics["qualityB"]=computeRegionalQuality(this -> chr, startSecondWindow, stopSecondWindow,300);
 			splitReadStatistics["links_window"]=int(statisticsFirstWindow[1]);
 			splitReadStatistics["coverage_start"]=statisticsFirstWindow[0];
-			splitReadStatistics["coverage_end"]=computeCoverageB(chr2, startSecondWindow, stopSecondWindow, (startchrA-startSecondWindow+1) );
+			splitReadStatistics["coverage_end"]=computeCoverageB(chr2, startSecondWindow, stopSecondWindow, (stopSecondWindow-startSecondWindow+1) );
 			VCFLine(discordantPairStatistics,splitReadStatistics,svType,GT,CN);
 			found = true;
 		}
@@ -845,7 +845,7 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 	
 		}else{
 			ss << ";EL="  << discordantPairStatistics["expected_links"] << ";RATIO=-1";
-				filter=filterFunction(1,discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage, discordantPairStatistics["windowA_start"], discordantPairStatistics["windowB_start"],discordantPairStatistics["chrA"],discordantPairStatistics["chrB"]);	
+				filter=filterFunction(1,discordantPairStatistics["links_chr"],discordantPairStatistics["links_event"],mean_insert,std_insert,discordantPairStatistics["coverage_start"],discordantPairStatistics["coverage_end"],meanCoverage, discordantPairStatistics["windowA_end"], discordantPairStatistics["windowB_start"],discordantPairStatistics["chrA"],discordantPairStatistics["chrB"]);	
 	
 		}
 		infoField += ss.str();
@@ -880,7 +880,7 @@ void Window::VCFLine(map<string,int> discordantPairStatistics, map<string,int> s
 		if(E_links > 0){
 			RATIO=this -> ploidy*double(splitReadStatistics["split_reads"])/double(E_links);
 		}
-		filter=filterFunction(RATIO,splitReadStatistics["split_reads"],splitReadStatistics["links_window"],mean_insert,std_insert,splitReadStatistics["coverage_start"],splitReadStatistics["coverage_end"],meanCoverage,splitReadStatistics["start"],splitReadStatistics["end"],splitReadStatistics["chrA"],splitReadStatistics["chrB"]);
+		filter=filterFunction(RATIO,splitReadStatistics["split_reads"],splitReadStatistics["links_window"],mean_insert,std_insert,splitReadStatistics["coverage_start"],splitReadStatistics["coverage_end"],meanCoverage,splitReadStatistics["windowA_end"],splitReadStatistics["windowB_start"],splitReadStatistics["chrA"],splitReadStatistics["chrB"]);
 		
 		
 		chrB= splitReadStatistics["chrB"];

--- a/src/data_structures/Translocation.h
+++ b/src/data_structures/Translocation.h
@@ -48,6 +48,7 @@ public:
 	map<string,unsigned int> contig2position;
 	map<unsigned int,string> position2contig;
 	vector< vector<float> > binnedCoverage;
+	vector< vector<float> > binnedQuality;
 	//Output part
 	string outputFileHeader;
 	ofstream interChrVariationsVCF;
@@ -65,6 +66,7 @@ public:
 	vector<long> newChrALimit(vector< vector< long > > variantPositions,long Bstart,long Bend); //resizes the window on CHRA
 	vector<double> computeStatisticsA(string bamFileName, int chrB, int start, int end, int32_t WindowLength, string indexFile); //compute coverage and number of links from window on the chrA
 	vector<string> classification(int chr, int startA,int endA,double covA,int startB,int endB,double covB,int meanInsert,int STDInsert,bool outtie);
+	float computeRegionalQuality(int chrB, int start, int end,int bin_size);
 	string VCFHeader();
 	void VCFLine(map<string,int> discordantPairStatistics, map<string,int> splitReadStatistics,string svType,string GT, string CN);
 	vector<int> findLinksToChr2(queue<BamAlignment> ReadQueue,long startChrA,long stopChrA,long startChrB,long endChrB, int pairsFormingLink);

--- a/src/data_structures/Translocation.h
+++ b/src/data_structures/Translocation.h
@@ -19,7 +19,7 @@ public:
 
 	vector< vector < queue<BamAlignment> > >	eventReads;
 	
-	vector< vector<BamAlignment> > eventSplitReads;
+	vector< vector < vector<BamAlignment> > > eventSplitReads;
 
 	vector<long> covOnChrA;
 	vector<long> tmpCovOnChrA;

--- a/src/data_structures/Translocation.h
+++ b/src/data_structures/Translocation.h
@@ -66,7 +66,7 @@ public:
 	vector<double> computeStatisticsA(string bamFileName, int chrB, int start, int end, int32_t WindowLength, string indexFile); //compute coverage and number of links from window on the chrA
 	vector<string> classification(int chr, int startA,int endA,double covA,int startB,int endB,double covB,int meanInsert,int STDInsert,bool outtie);
 	string VCFHeader();
-	void VCFLine(int chr2,int startSecondWindow, int stopSecondWindow,int startchrA,int stopchrA,int pairsFormingLink,int splitsFormingLink,int numLinksToChr2,int estimatedDistance);
+	void VCFLine(map<string,int> discordantPairStatistics, map<string,int> splitReadStatistics,string svType,string GT, string CN);
 	vector<int> findLinksToChr2(queue<BamAlignment> ReadQueue,long startChrA,long stopChrA,long startChrB,long endChrB, int pairsFormingLink);
 	float computeCoverageB(int chrB, int start, int end, int32_t secondWindowLength); //computes the coverage of the window of chromosome B
 	bool computeVariations(int chr2);

--- a/src/data_structures/Translocation.h
+++ b/src/data_structures/Translocation.h
@@ -61,8 +61,8 @@ public:
 	void initTrans(SamHeader head);				   // initialise the contig to position array
 	void insertRead(BamAlignment alignment);	   // inserts a new read
 	queue<BamAlignment> queueAppend(queue<BamAlignment> queueOne,queue<BamAlignment> queueTwo); //append queues;
-	vector<long> findRegionOnB( queue<BamAlignment> alignmentQueue, int minimumPairs,int maxDistance); //Finds the region of the event on chromosome B
-	vector<long> newChrALimit(queue<BamAlignment> alignmentQueue,long Bstart,long Bend); //resizes the window on CHRA
+	vector<long> findRegionOnB( vector<long> mate_positions, int minimumPairs,int maxDistance); //Finds the region of the event on chromosome B
+	vector<long> newChrALimit(vector< vector< long > > variantPositions,long Bstart,long Bend); //resizes the window on CHRA
 	vector<double> computeStatisticsA(string bamFileName, int chrB, int start, int end, int32_t WindowLength, string indexFile); //compute coverage and number of links from window on the chrA
 	vector<string> classification(int chr, int startA,int endA,double covA,int startB,int endB,double covB,int meanInsert,int STDInsert,bool outtie);
 	string VCFHeader();

--- a/src/data_structures/findTranslocationsOnTheFly.cpp
+++ b/src/data_structures/findTranslocationsOnTheFly.cpp
@@ -31,6 +31,7 @@ void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool o
 	window->eventSplitReads.resize(SV_options["contigsNumber"]);
 
 	window-> binnedCoverage.resize(SV_options["contigsNumber"]);
+	window-> binnedQuality.resize(SV_options["contigsNumber"]);
 	
 	window-> linksFromWin.resize(4);
 	window-> linksFromWin[0].resize(SV_options["contigsNumber"]);
@@ -53,6 +54,7 @@ void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool o
         		splitline.push_back(item);
     		}
 			window -> binnedCoverage[window -> contig2position[splitline[0]]].push_back(atof(splitline[3].c_str()));
+			window -> binnedQuality[window -> contig2position[splitline[0]]].push_back(atof(splitline[4].c_str()));
 		}
 		line_number += 1;
 	}

--- a/src/data_structures/findTranslocationsOnTheFly.cpp
+++ b/src/data_structures/findTranslocationsOnTheFly.cpp
@@ -28,7 +28,11 @@ void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool o
 	window->eventReads[2].resize(SV_options["contigsNumber"]);
 	window->eventReads[3].resize(SV_options["contigsNumber"]);
 	
-	window->eventSplitReads.resize(SV_options["contigsNumber"]);
+	window->eventSplitReads.resize(4);
+	window->eventSplitReads[0].resize(SV_options["contigsNumber"]);
+	window->eventSplitReads[1].resize(SV_options["contigsNumber"]);
+	window->eventSplitReads[2].resize(SV_options["contigsNumber"]);
+	window->eventSplitReads[3].resize(SV_options["contigsNumber"]);
 
 	window-> binnedCoverage.resize(SV_options["contigsNumber"]);
 	window-> binnedQuality.resize(SV_options["contigsNumber"]);
@@ -79,8 +83,10 @@ void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool o
 				window->computeVariations(i);
 			}
 			window->eventReads[j][i]=queue<BamAlignment>();
+			window->eventSplitReads[j][i] = vector<BamAlignment>();
+			window->linksFromWin[j][i]=queue<int>();
 		}
-		window->eventSplitReads[i] = vector<BamAlignment>();
+		
 		
 	}
 	


### PR DESCRIPTION
Added split read detection of variants larger than 200 bp.

Added computation of the average mapping quality in bins overlapping the regions of the discordant pairs.

changed some constants to increase precision

The maximum distance of reads within the same cluster is changed from 1kb to 2*(mean insert size)/(minimum number of pairs) bases