### PR TITLE
Final edits before benchmarking

### DIFF
--- a/src/TIDDIT.cpp
+++ b/src/TIDDIT.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 	//MAIN VARIABLE
 
 	bool outtie 				    = true;	 // library orientation
-	uint32_t minimumSupportingPairs = 8;
+	uint32_t minimumSupportingPairs = 6;
 	int min_insert				    = 100;      // min insert size
 	int max_insert				    = 100000;  // max insert size
 	int minimum_mapping_quality		=10;
@@ -42,6 +42,7 @@ int main(int argc, char **argv) {
 	float coverageStd;
 	float meanInsert;
 	float insertStd;
+	int min_variant_size= 250;
 	string outputFileHeader ="output";
 	
 	
@@ -68,14 +69,16 @@ int main(int argc, char **argv) {
 	vm["-q"]="";
 	vm["-c"]="";
 	vm["--plody"]="";
+	vm["-m"] = "";
 	
 	string sv_help ="\nUsage: TIDDIT --sv -b inputfile [-o prefix] \nOther options\n";
-	sv_help +="\t--insert\tpaired reads maximum allowed insert size. Pairs aligning on the same chr at a distance higher than this are considered candidates for SV (if not specified default=3std + mean_insert_size)\n";
+	sv_help +="\t--insert\tpaired reads maximum allowed insert size. Pairs aligning on the same chr at a distance higher than this are considered candidates for SV (if not specified default=5std + mean_insert_size)\n";
 	sv_help +="\t--orientation\texpected reads orientations, possible values \"innie\" (-> <-) or \"outtie\" (<- ->). Default: major orientation within the dataset\n";
-	sv_help +="\t-p\tMinimum number of supporting pairs in order to call a variation event (default 8)\n";
+	sv_help +="\t-p\tMinimum number of supporting pairs in order to call a variation event (default 6)\n";
 	sv_help +="\t-q\tMinimum mapping quality to consider an alignment (default 10)\n";
 	sv_help +="\t-c\taverage coverage, (default= computed from the bam file)\n";
 	sv_help +="\t--plody\tthe number of sets of chromosomes,(default = 2)\n";
+	sv_help +="\t-m\tminimum variant size,(default = 250)\n";
 			
 	//the coverage module
 	vm["--cov"]="store";
@@ -229,6 +232,10 @@ int main(int argc, char **argv) {
             ploidy = convert_str( vm["--plody"],"--plody" );
         }
         
+        if (vm["-m"] != ""){
+        	min_variant_size = convert_str( vm["-m"],"-m" );
+        }
+        
         map<string,int> SV_options;
 		SV_options["max_insert"]      = max_insert;
 		SV_options["pairs"]           = minimumSupportingPairs;
@@ -238,6 +245,7 @@ int main(int argc, char **argv) {
 		SV_options["contigsNumber"]   = contigsNumber;
         SV_options["meanInsert"]      = meanInsert;
         SV_options["STDInsert"]       = insertStd;
+        SV_options["min_variant_size"]	  = min_variant_size;
         
 		StructuralVariations *FindTranslocations;
 		FindTranslocations = new StructuralVariations();		

--- a/src/common.h
+++ b/src/common.h
@@ -280,7 +280,7 @@ static LibraryStatistics computeLibraryStats(string bamFileName, uint64_t genome
         
 		if (al.IsFirstMate() && al.IsMateMapped() and read_status != lowQualty ) {
 			if( al.IsReverseStrand() != al.IsMateReverseStrand() ){
-				if(al.IsMapped() and al.MapQuality > quality and al.RefID == al.MateRefID and al.MatePosition-al.Position+1 < max_insert ){
+				if(al.IsMapped() and al.MapQuality > 30 and al.RefID == al.MateRefID and al.MatePosition-al.Position+1 < max_insert ){
 					iSize = abs(al.InsertSize);
 					if(counterK == 1) {
 						Mk = iSize;

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -226,7 +226,7 @@ void Window::insertRead(BamAlignment alignment) {
 				//empty the alignmentqueues
 				eventReads[j][i]=queue<BamAlignment>();
 				eventSplitReads[j][i]=vector<BamAlignment>();
-				linksFromWin[j][alignment.MateRefID]=queue<int>();
+				linksFromWin[j][i]=queue<int>();
 			}
 			
 			

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -318,7 +318,7 @@ void Window::insertRead(BamAlignment alignment) {
 			//if we have any active set on these pairs of contigs
 			if(eventSplitReads[this -> pairOrientation][contigNr].size() > 0 or eventReads[this -> pairOrientation][contigNr].size() > 0){
 				//if we are close enough
-				if (discordantDistance <= 2*mean_insert/minimumPairs or splitDistance <= this -> readLength){
+				if (discordantDistance <= 12*sqrt(mean_insert) or splitDistance <= this -> readLength){
 					eventSplitReads[this -> pairOrientation][contigNr].push_back(alignment);
 				}else{
 					if(eventReads[this -> pairOrientation][contigNr].size() >= minimumPairs or eventSplitReads[this -> pairOrientation][contigNr].size() > minimumPairs){
@@ -371,7 +371,7 @@ void Window::insertRead(BamAlignment alignment) {
 				int distance= currrentAlignmentPos - pastAlignmentPos;
 
 				//If the distance between the two reads is less than the maximum allowed distace, add it to the other reads of the event
-				if(distance <= 2*mean_insert/minimumPairs){
+				if(distance <= 12*sqrt(mean_insert)){
 					//add the read to the current window
 					eventReads[this -> pairOrientation][alignment.MateRefID].push(alignment);
 				}else{
@@ -545,7 +545,7 @@ bool Window::computeVariations(int chr2) {
 	}
 	
 	if(discordantPairs){
-		vector<long> chr2regions= findRegionOnB( discordantPairPositions[1] ,minimumPairs,2*mean_insert/minimumPairs);
+		vector<long> chr2regions= findRegionOnB( discordantPairPositions[1] ,minimumPairs,12*sqrt(mean_insert));
 	
 		for(int i=0;i < chr2regions.size()/3;i++){
 			long startSecondWindow=chr2regions[i*3];

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -911,7 +911,7 @@ void Window::VCFLine(map<string,float> statistics_floats,map<string,int> discord
 		}
 
 		double RATIO =1;
-		int E_links= splitReadStatistics["coverage_start"]/(double(this -> ploidy));
+		int E_links= (statistics_floats["coverage_start"]+statistics_floats["coverage_end"])/(double(this -> ploidy))*1/2;
 		if(E_links > 0){
 			RATIO=double(splitReadStatistics["split_reads"])/double(E_links);
 		}

--- a/src/data_structures/Translocation.h
+++ b/src/data_structures/Translocation.h
@@ -39,6 +39,7 @@ public:
 	float meanCoverage;
 	int ploidy;
 	int readLength;
+	int minimumVariantSize;
 	//the file name of the bamfile
 	string bamFileName;
 	string indexFile;

--- a/src/data_structures/VcfBedInput.cpp
+++ b/src/data_structures/VcfBedInput.cpp
@@ -1,6 +1,7 @@
 #include "ProgramModules.h"
 #include "common.h"
 #include <boost/algorithm/string.hpp>
+#include <math>
 
 //constructor
 VcfBedInput::VcfBedInput() {}

--- a/variant_assembly_filter/compute_contig_support.py
+++ b/variant_assembly_filter/compute_contig_support.py
@@ -1,0 +1,89 @@
+import argparse
+import os
+import sys
+import random
+import glob
+
+parser = argparse.ArgumentParser("""extracts the alignments of structural variants called by TIDDIT""")
+parser.add_argument('--fa',type=str,required = True,help="the fa file containing the contigs of the variant")
+parser.add_argument('--TIDDIT',type=str,help="the path to TIDDIT(defaut = TIDDIT)", default="TIDDIT")
+parser.add_argument('--bam',type=str,required = True,help="the path to the bam containing reads of the extracted region")
+parser.add_argument('--prefix',type=str,default="assemlatron",help="path to the output dir(default is pwd)")
+args, unknown = parser.parse_known_args()
+contigs={}
+current_header=""
+contig_list=[]
+
+for line in open(args.fa):
+    if ">" in line:
+        current_header=line[1:].strip().split()[0]
+    else:
+        contigs[current_header]={}
+        
+        contigs[current_header]["contig"]=line.strip()
+        contig_list.append(line.strip())
+os.system("bwa index {} ".format(args.fa))
+os.system("samtools bam2fq  {} | bwa mem {} - | samtools view -bhS - | samtools sort - {}_contig_aln".format(args.bam,args.fa,args.prefix))
+os.system("{} --cov --bin_size 1000000 -b {}_contig_aln.bam -o {}".format(args.TIDDIT, args.prefix , args.prefix))   
+
+for line in open(args.prefix+".tab"):
+    if line[0] == "#":
+        continue
+    content=line.split("\t")
+    contigs[content[0]]["coverage"]=float(content[3])
+    contigs[content[0]]["length"]=int(content[2])    
+    
+    
+for contig in contigs:
+    coverage=contigs[contig]["length"]
+    
+    p=0
+    n=100
+    for i in range(0,n):
+        f=open(args.prefix+"_{}.fa".format(i),"w")   
+        for test_contig in contigs:
+            if test_contig == contig:
+                continue
+                
+            f.write(">" + test_contig+"\n")
+            f.write(contigs[test_contig]["contig"]+"\n")
+        sequence=""
+        while True:
+            selected_contig=random.randint(0,len(contig_list)-1)
+
+            selected_len=random.randint(5,40)
+            selected_pos=random.randint(0,len(contig_list[selected_contig])-selected_len)
+            sequence += contig_list[ selected_contig ][ selected_pos  : selected_pos+selected_len  ]
+            if len(sequence) >= contigs[contig]["length"]:
+                sequence=sequence[0:contigs[contig]["length"]]
+                break
+        f.write(">simulated_contig\n")
+        f.write(sequence+"\n")
+        f.close()
+        os.system("bwa index {} ".format(args.prefix+"_{}.fa".format(i)))
+        os.system("samtools bam2fq  {} | bwa mem {} - | samtools view -bhS - | samtools sort - {}_contig_aln_{}".format(args.bam, args.prefix+"_{}.fa".format(i) ,args.prefix,i))
+        os.system("{} --cov --bin_size 1000000 -b {}_contig_aln_{}.bam -o {}_{}".format(args.TIDDIT, args.prefix,i,args.prefix,i))  
+        
+        for line in open("{}_{}.tab".format(args.prefix,i)):
+            if line[0] == "#":
+                continue
+            content=line.split("\t")
+            if "simulated_contig" in content[0]:
+                if float(content[3]) >= contigs[contig]["coverage"]:
+                    p += 1
+        
+        for f in glob.glob(args.prefix+"_{}*".format(i)):
+            os.remove(f)
+        for f in glob.glob(args.prefix+"_contig_aln_{}*".format(i)):
+            os.remove(f)
+    p=p/float(n)
+    contigs[contig]["significant"]="True"
+    contigs[contig]["p"]=p
+    if p > 0.05:
+        contigs[contig]["significant"]="False"
+    
+f=open(args.prefix+".fa","w")  
+for contig in contigs:
+    f.write(">" + contig+" length:{} significant:{} Pval:{} coverage:{}\n".format(contigs[contig]["length"],contigs[contig]["significant"],contigs[contig]["p"],contigs[contig]["coverage"]))
+    f.write(contigs[contig]["contig"]+"\n")
+f.close()


### PR DESCRIPTION
Removed the hardcoded sv size limit, now the limit may be set using the -m flag

Fixed a bug that caused segmentation fault for some samples

The distance to merge reads into the same event is increased to 12*sqrt(mean insert)

default number of discordant pairs is lowered to 6
