### PR TITLE
Reorder the filters

### DIFF
--- a/TIDDIT.py
+++ b/TIDDIT.py
@@ -7,7 +7,7 @@ wd=os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, '{}/src/'.format(wd))
 import TIDDIT_clustering
 
-version = "2.2.5"
+version = "2.2.6"
 parser = argparse.ArgumentParser("""TIDDIT-{}""".format(version),add_help=False)
 parser.add_argument('--sv'       , help="call structural variation", required=False, action="store_true")
 parser.add_argument('--cov'        , help="generate a coverage bed file", required=False, action="store_true")

--- a/src/TIDDIT.cpp
+++ b/src/TIDDIT.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
 	float insertStd;
 	int min_variant_size= 100;
 	string outputFileHeader ="output";
-	string version = "2.2.5";
+	string version = "2.2.6";
 	
 	//collect all options as a vector
 	vector<string> arguments(argv, argv + argc);

--- a/src/TIDDIT_clustering.py
+++ b/src/TIDDIT_clustering.py
@@ -432,9 +432,6 @@ def fetch_variant_type(chrA,chrB,candidate,args,library_stats):
 #compute the filters
 def fetch_filter(chrA,chrB,candidate,args,library_stats):
 	filt="PASS"
-	#fewer links than expected
-	if chrA == chrB and (abs(candidate["max_A"]-candidate["min_B"]) < args.z):
-		filt="MinSize"
 
 	#Less than the expected number of signals
 	if candidate["discs"] and not ( candidate["splits"] and abs(candidate["posA"]-candidate["posB"]) < 3*library_stats["STDInsertSize"] and chrA == chrB ):
@@ -461,6 +458,10 @@ def fetch_filter(chrA,chrB,candidate,args,library_stats):
 			filt= "SplitsVSDiscs"
 	elif candidate["QRA"] < args.Q or candidate["QRB"] < args.Q:
 		filt = "RegionalQ"
+
+	#fewer links than expected
+	if chrA == chrB and (abs(candidate["max_A"]-candidate["min_B"]) < args.z):
+		filt="MinSize"
 
 	return(filt)
 


### PR DESCRIPTION
Sometimes, too small variants are filtered using other filters than the MinSize filter.
With this update, all variants that are less than MinSize will be flagged as MinSize.