### PR TITLE
2.9.0

### DIFF
--- a/TIDDIT.py
+++ b/TIDDIT.py
@@ -8,7 +8,7 @@ wd=os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, '{}/src/'.format(wd))
 import TIDDIT_calling
 
-version = "2.8.1"
+version = "2.9.0"
 parser = argparse.ArgumentParser("""TIDDIT-{}""".format(version),add_help=False)
 parser.add_argument('--sv'       , help="call structural variation", required=False, action="store_true")
 parser.add_argument('--cov'        , help="generate a coverage bed file", required=False, action="store_true")

--- a/src/TIDDIT.cpp
+++ b/src/TIDDIT.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 	uint32_t minimumSupportingPairs = 4;
 	uint32_t minimumSupportingReads = 6;
 	int min_insert = 100;      // min insert size
-	int max_insert = 80000;  // max insert size
+	int max_insert = 100000;  // max insert size
 	int minimum_mapping_quality = 10;
 	float coverage;
 	float coverageStd;
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
 	int min_variant_size= 100;
 	int sample = 100000000;
 	string outputFileHeader ="output";
-	string version = "2.8.1";
+	string version = "2.9.0";
 	
 	//collect all options as a vector
 	vector<string> arguments(argv, argv + argc);
@@ -409,7 +409,7 @@ int main(int argc, char **argv) {
 
 		meanInsert = library.insertMean;
 		insertStd  = library.insertStd;
-		max_insert=library.percentile;
+		max_insert=library.percentile+100;
 
 		if(vm["-i"] != ""){
 			max_insert  = convert_str( vm["-i"], "-i");


### PR DESCRIPTION
The insert size treshold is not set to 99.9th percentile + 100 bp, this will prevent too many readpairs from being discordaant in a very clean library