### PR TITLE
Stream bam file/cram support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories("${PROJECT_SOURCE_DIR}/lib/bamtools/src")
 file(GLOB TIDDIT_FILES
     ${PROJECT_SOURCE_DIR}/src/TIDDIT.cpp
     ${PROJECT_SOURCE_DIR}/src/data_structures/Translocation.cpp
-	${PROJECT_SOURCE_DIR}/src/data_structures/findTranslocationsOnTheFly.cpp
+    ${PROJECT_SOURCE_DIR}/src/data_structures/findTranslocationsOnTheFly.cpp
     ${PROJECT_SOURCE_DIR}/src/common.h
     ${PROJECT_SOURCE_DIR}/src/data_structures/CoverageModule.cpp
 )

--- a/TIDDIT.py
+++ b/TIDDIT.py
@@ -8,7 +8,7 @@ wd=os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, '{}/src/'.format(wd))
 import TIDDIT_calling
 
-version = "2.10.0"
+version = "2.11.0"
 parser = argparse.ArgumentParser("""TIDDIT-{}""".format(version),add_help=False)
 parser.add_argument('--sv'       , help="call structural variation", required=False, action="store_true")
 parser.add_argument('--cov'        , help="generate a coverage bed file", required=False, action="store_true")
@@ -27,13 +27,16 @@ if args.sv:
 	parser.add_argument('-Q', type=int,default=20, help="Minimum regional mapping quality (default 20)")
 	parser.add_argument('-n', type=int,default=2, help="the ploidy of the organism,(default = 2)")
 	parser.add_argument('-e', type=int, help="clustering distance  parameter, discordant pairs closer than this distance are considered to belong to the same variant(default = sqrt(insert-size*2)*12)")
-	parser.add_argument('-l', type=int,default=3, help="min-pts parameter (default=3),must be set > 2")
-	parser.add_argument('-s', type=int,default=20000000, help="Number of reads to sample when computing library statistics(default=50000000)")
+	parser.add_argument('-l', type=int,default=3, help="min-pts parameter (default=3),must be set >= 2")
+	parser.add_argument('-s', type=int,default=25000000, help="Number of reads to sample when computing library statistics(default=25000000)")
 	parser.add_argument('-z', type=int,default=100, help="minimum variant size (default=100), variants smaller than this will not be printed ( z < 10 is not recomended)")
 	parser.add_argument('--force_ploidy',action="store_true", help="force the ploidy to be set to -n across the entire genome (i.e skip coverage normalisation of chromosomes)")
+	parser.add_argument('--no_cluster',action="store_true", help="Run only the TIDDIT signal extraction")
 	parser.add_argument('--debug',action="store_true", help="rerun the tiddit clustering procedure")
 	parser.add_argument('--n_mask',type=float,default=0.5, help="exclude regions from coverage calculation if they contain more than this fraction of N (default = 0.5)")
-	parser.add_argument('--ref', type=str, help="reference fasta, used for GC correction")
+	parser.add_argument('--ref', type=str, help="reference fasta, used for GC correction and for reading cram")
+	parser.add_argument('--p_ratio', type=float,default=0.2, help="minimum discordant pair/normal pair ratio at the breakpoint junction(default=20%)")
+	parser.add_argument('--r_ratio', type=float,default=0.1, help="minimum split read/coverage ratio at the breakpoint junction(default=10%)")
 
 	args= parser.parse_args()
 	args.wd=os.path.dirname(os.path.realpath(__file__))
@@ -44,11 +47,16 @@ if args.sv:
 		if not os.path.isfile(args.ref):
 			print ("error,  could not find the reference file")
 			quit()
-	if not args.bam.endswith(".bam"):
-		print ("error, the input file is not a bam file, make sure that the file extension is .bam")
+
+	if not args.ref and args.bam.endswith(".cram"):
+		print("error, reference fasta is required when using cram input")
 		quit()
 
-	if not os.path.isfile(args.bam):
+	if not (args.bam.endswith(".bam") or args.bam.endswith(".cram")) and not "/dev/" in args.bam:
+		print ("error, the input file is not a bam file, make sure that the file extension is .bam or .cram")
+		quit()
+
+	if not os.path.isfile(args.bam) and not "/dev/" in args.bam:
 		print ("error,  could not find the bam file")
 		quit()
 
@@ -56,7 +64,12 @@ if args.sv:
 		print ("error,  could not find the TIDDIT executable file, try rerun the INSTALL.sh script")
 		quit()
 
-	command_str="{}/bin/TIDDIT --sv -b {} -o {} -p {} -r {} -q {} -n {} -s {}".format(args.wd,args.bam,args.o,args.p,args.r,args.q,args.n,args.s)
+	if not args.bam.endswith(".cram"):
+		command_str="{}/bin/TIDDIT --sv -b {} -o {} -p {} -r {} -q {} -n {} -s {}".format(args.wd,args.bam,args.o,args.p,args.r,args.q,args.n,args.s)
+	else:
+		command_str="samtools view -hbu {} -T {} | {}/bin/TIDDIT --sv -b /dev/stdin -o {} -p {} -r {} -q {} -n {} -s {}".format(args.bam,args.ref,args.wd,args.o,args.p,args.r,args.q,args.n,args.s)
+	
+
 	if args.i:
 		command_str += " -i {}".format(args.i)
 	if args.d:
@@ -74,7 +87,8 @@ if args.sv:
 				os.system("cat {} | {}/bin/TIDDIT --gc -z 50 -o {}".format(args.ref,args.wd,args.o))
 			print ("Constructed GC wig in {} sec".format(time.time()-t))
 
-	TIDDIT_calling.cluster(args)
+	if not args.no_cluster:
+		TIDDIT_calling.cluster(args)
 
 elif args.cov:
 	parser = argparse.ArgumentParser("""TIDDIT --cov --bam inputfile [-o prefix]""")
@@ -84,9 +98,23 @@ elif args.cov:
 	parser.add_argument('-z', type=int,default=500, help="use bins of specified size(default = 500bp) to measure the coverage of the entire bam file, set output to stdout to print to stdout")
 	parser.add_argument('-w'        , help="generate wig instead of bed", required=False, action="store_true")
 	parser.add_argument('-u'        , help="skip per bin mapping quality", required=False, action="store_true")
+	parser.add_argument('--ref', type=str, help="reference fasta, used for GC correction and for reading cram")
 	args= parser.parse_args()
 	args.wd=os.path.dirname(os.path.realpath(__file__))
-	command="{}/bin/TIDDIT --cov -b {} -o {} -z {}".format(args.wd,args.bam,args.o,args.z)
+
+	if args.ref:
+		if not os.path.isfile(args.ref):
+			print ("error,  could not find the reference file")
+			quit()
+
+	if not args.bam.endswith(".cram"):
+		command="{}/bin/TIDDIT --cov -b {} -o {} -z {}".format(args.wd,args.bam,args.o,args.z)
+	else:
+		if not args.ref:
+			print("error, missing reference sequence!")
+			quit()
+		command="samtools view -hbu {} -T {} | {}/bin/TIDDIT --cov -b /dev/stdin -o {} -z {}".format(args.bam,args.ref,args.wd,args.o,args.z)
+
 	if args.w:
 		command += " -w"
 

--- a/src/DBSCAN.py
+++ b/src/DBSCAN.py
@@ -98,7 +98,11 @@ def analyse_pos(candidate_signals,discordants,library_stats,args):
 def generate_clusters(chrA,chrB,coordinates,library_stats,args):
 	candidates=[]
 	coordinates=coordinates[numpy.lexsort((coordinates[:,1],coordinates[:,0]))]
-	db=main(coordinates[:,0:2],args.e,int(round(args.l+library_stats["ploidies"][chrA]/(args.n*10))))
+	min_pts=args.l
+	if chrA == chrB and library_stats["ploidies"][chrA] > args.n*2:
+		min_pts=int(round(args.l/float(args.n)*library_stats["ploidies"][chrA]))
+
+	db=main(coordinates[:,0:2],args.e,min_pts)
 	unique_labels = set(db)
 
 	for var in unique_labels:

--- a/src/TIDDIT_calling.py
+++ b/src/TIDDIT_calling.py
@@ -140,7 +140,13 @@ def generate_vcf_line(chrA,chrB,n,candidate,args,library_stats,percentiles,span_
 	vcf_line.append(FORMAT_FORMAT)
 	CN="."
 	if "DEL" in var or "DUP" in var:
-		CN=int(round(candidate["covM"]/(library_stats["Coverage"]/args.n)))
+		if library_stats["Coverage"]:
+			CN=int(round(candidate["covM"]/(library_stats["Coverage"]/args.n)))
+		elif library_stats["chr_cov"][chrA]:
+			CN=int(round(candidate["covM"]/(library_stats["chr_cov"][chrA]/library_stats["ploidies"][chrA])))
+		else:
+			CN=0
+
 	if "DEL" in var:
 		CN=library_stats["ploidies"][chrA]-CN
 		if CN < 0:

--- a/src/TIDDIT_filtering.py
+++ b/src/TIDDIT_filtering.py
@@ -5,15 +5,26 @@ def fetch_filter(chrA,chrB,candidate,args,library_stats):
 	filt="PASS"
 
 	#Less than the expected number of signals
-	ratio_scaling=min([ candidate["covA"]/library_stats["chr_cov"][chrA], candidate["covB"]/library_stats["chr_cov"][chrB] ])
+	r_a=0
+	if library_stats["chr_cov"][chrA]:
+		r_a=candidate["covA"]/library_stats["chr_cov"][chrA]
+	r_b=0
+	if library_stats["chr_cov"][chrB]:
+		r_b=candidate["covB"]/library_stats["chr_cov"][chrB]
+
+
+	ratio_scaling=min([ r_b, r_a ])
+
 	if ratio_scaling > 2:
 		ratio_scaling=2
 	elif ratio_scaling < 1:
 		ratio_scaling=1
 
-	if candidate["ratio"]*ratio_scaling <= 0.2 and candidate["discs"] > candidate["splits"]:
+	if chrA == chrB and library_stats["ploidies"][chrA] > 10 and candidate["ratio"] <= 0.05:
 		filt = "BelowExpectedLinks"
-	elif candidate["ratio"]*ratio_scaling <= 0.1 and candidate["discs"] < candidate["splits"]:
+	elif candidate["ratio"]*ratio_scaling <= args.p_ratio and candidate["discs"] > candidate["splits"]:
+		filt = "BelowExpectedLinks"
+	elif candidate["ratio"]*ratio_scaling <= args.r_ratio and candidate["discs"] < candidate["splits"]:
 		filt = "BelowExpectedLinks"
 
 	#The ploidy of this contig is 0, hence there shoud be no variant here

--- a/src/data_structures/ProgramModules.h
+++ b/src/data_structures/ProgramModules.h
@@ -17,7 +17,7 @@ public:
 	//constructor
 	StructuralVariations();
 	//main function
-	void findTranslocationsOnTheFly(string bamFileName, bool outtie, float meanCoverage,string outputFileHeader,string version,string commandline, map<string,int> SV_options,uint64_t genomeLength);
+	void findTranslocationsOnTheFly(string bamFileName,BamReader bamFile, bool outtie, float meanCoverage,string outputFileHeader,string version,string commandline, map<string,int> SV_options,uint64_t genomeLength);
 };
 
 #endif /* PROGRAMMODULES_H_ */

--- a/src/data_structures/Translocation.cpp
+++ b/src/data_structures/Translocation.cpp
@@ -52,21 +52,20 @@ void Window::printHeader(SamHeader head,string libraryData) {
 
 void Window::insertRead(BamAlignment alignment,readStatus alignmentStatus) {
 
-	if( not alignment.IsMateMapped()  or alignmentStatus == lowQualty) {
+	if( not alignment.IsMateMapped() ) {
 		return; // in case the alignment is of no use discard it
 	}
 
-	if(this->chr == -1) { //sets chr to the first chromosome at startup
-		cout << "working on sequence " << position2contig[alignment.RefID] << "\n";
-		chr=alignment.RefID;
-	}
+	//if(this->chr == -1) { //sets chr to the first chromosome at startup
+	//	cout << "working on sequence " << position2contig[alignment.RefID] << "\n";
+	//}
 
-	if(alignment.RefID != chr) { // I am moving to a new chromosomes, need to check if the current window can be used or not
+	if(alignment.RefID != this->chr) { // I am moving to a new chromosomes, need to check if the current window can be used or not
 		cout << "working on seqence " << position2contig[alignment.RefID] << "\n";
+		this-> chr=alignment.RefID;
 	}
 	
 	bool alignment_split = false;	
-	alignment.BuildCharData();			
 	alignment_split = alignment.HasTag("SA");
 	if (alignment_split and alignment.IsPrimaryAlignment() and not alignment.IsSupplementaryAlignment() and alignment.MapQuality >= minimum_mapping_quality) {
 		// parse split read to get the other segment position, akin to a mate.
@@ -223,12 +222,13 @@ string Window::VCFHeader(string libraryData){
 Window::Window(string bamFileName, bool outtie, float meanCoverage,string outputFileHeader, map<string,int> SV_options) {
 	this->max_insert		 = SV_options["max_insert"];
 	this->minimum_mapping_quality = SV_options["mapping_quality"];
-	this->outtie			 = outtie;
-	this->mean_insert		 = SV_options["meanInsert"];
-	this ->std_insert		 = SV_options["STDInsert"];
-	this->bamFileName		 = bamFileName;
-	this -> ploidy           = SV_options["ploidy"];
-	this -> readLength       = SV_options["readLength"];
-	this -> pairOrientation				 = 0;          
-	this->outputFileHeader     = outputFileHeader;
+	this->outtie			= outtie;
+	this->mean_insert		= SV_options["meanInsert"];
+	this ->std_insert		= SV_options["STDInsert"];
+	this->bamFileName		= bamFileName;
+	this -> ploidy			= SV_options["ploidy"];
+	this -> readLength		= SV_options["readLength"];
+	this -> pairOrientation		= 0;          
+	this->outputFileHeader		= outputFileHeader;
+	this -> chr 			= -1;
 }

--- a/src/data_structures/findTranslocationsOnTheFly.cpp
+++ b/src/data_structures/findTranslocationsOnTheFly.cpp
@@ -9,16 +9,15 @@
 //function used to find translocations
 StructuralVariations::StructuralVariations() { }
 
-void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool outtie, float meanCoverage, string outputFileHeader, string version,string command, map<string,int> SV_options,uint64_t genomeLength) {
+void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, BamReader bamFile, bool outtie, float meanCoverage, string outputFileHeader, string version,string command, map<string,int> SV_options,uint64_t genomeLength) {
 	size_t start = time(NULL);
-	//open the bam file
-	BamReader bamFile;
-	bamFile.Open(bamFileName);
 	//Information from the header is needed to initialize the data structure
+
 	SamHeader head = bamFile.GetHeader();
 
 	Window *window;
 	window = new Window(bamFileName,outtie,meanCoverage,outputFileHeader,SV_options);
+
 	window-> version = version;
 	window->initTrans(head);
 
@@ -27,35 +26,60 @@ void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool o
 		orientation_string="outtie";
 	}
 
-
 	for (int i=0;i< SV_options["contigsNumber"];i++){window -> SV_calls[i] = vector<string>();}
 
-	//Initialize bam entity
-	BamAlignment currentRead;
-
         Cov *calculateCoverage;
-        calculateCoverage = new Cov(50,bamFileName,outputFileHeader,SV_options["mapping_quality"],true,false,true);
+        calculateCoverage = new Cov(50,head,outputFileHeader,SV_options["mapping_quality"],true,false,true);
 
 	uint64_t mappedReadsLength= 0;
+	//analyse the already sampled reads
+
+	BamAlignment currentRead;
+        BamReader sampleBamFile;
+        sampleBamFile.Open(outputFileHeader+".sample.bam");
+	sampleBamFile.Rewind();
+
+	while ( sampleBamFile.GetNextAlignmentCore(currentRead) ){
+		if(currentRead.IsMapped()){
+			readStatus alignmentStatus = computeReadType(currentRead, window->max_insert,window-> min_insert, window-> outtie);
+
+        		if( alignmentStatus == lowQualty) {
+				continue;
+		        }
+		
+			currentRead.BuildCharData();
+			window->insertRead(currentRead, alignmentStatus);
+			calculateCoverage -> bin(currentRead, alignmentStatus);
+
+			mappedReadsLength+= currentRead.Length;
+		}
+
+	}
+	sampleBamFile.Close();
 
 	//now start to iterate over the bam file
 	while ( bamFile.GetNextAlignmentCore(currentRead) ) {
 		if(currentRead.IsMapped()){
+
 			readStatus alignmentStatus = computeReadType(currentRead, window->max_insert,window-> min_insert, window-> outtie);
+
+        		if( alignmentStatus == lowQualty) {
+				continue;
+		        }
+
+			currentRead.BuildCharData();
 			window->insertRead(currentRead, alignmentStatus);
-
 			calculateCoverage -> bin(currentRead, alignmentStatus);
-
-			if (alignmentStatus != lowQualty){mappedReadsLength+= currentRead.Length;}
+			mappedReadsLength+= currentRead.Length;
 		}
-	}
 
+	}
 	//print header
 	stringstream ss;
 	ss << "##LibraryStats=TIDDIT-" << version <<   " Coverage=" << float(mappedReadsLength)/genomeLength << " ReadLength=" << SV_options["readLength"] << " MeanInsertSize=" << SV_options["meanInsert"] << " STDInsertSize=" << SV_options["STDInsert"] << " Orientation=" << orientation_string << "\n" << "##TIDDITcmd=\"" << command << "\""; 
 	string libraryData=ss.str();
 	window->printHeader(head,libraryData);
-	
+
 	//print calls
 	for(int i=0;i< SV_options["contigsNumber"];i++){
 		for (int j=0;j < window -> SV_calls[i].size();j++){
@@ -67,9 +91,10 @@ void StructuralVariations::findTranslocationsOnTheFly(string bamFileName, bool o
 		window-> TIDDITVCF <<  it-> second;
 	} 
 
-
 	window->TIDDITVCF.close();
 
 	calculateCoverage -> printCoverage();
 	printf ("signal extraction time consumption= %lds\n", time(NULL) - start);
+	exit(0);
+
 }


### PR DESCRIPTION
	TIDDIT now allows streamed bam file as input

        CRAM input is supported by wrapping around samtools

        modified:   TIDDIT.py
	modified:   src/DBSCAN.py
	modified:   src/TIDDIT.cpp
	modified:   src/TIDDIT_calling.py
	modified:   src/TIDDIT_filtering.py
	modified:   src/common.h
	modified:   src/data_structures/CoverageModule.cpp
	modified:   src/data_structures/ProgramModules.h
	modified:   src/data_structures/Translocation.cpp
	modified:   src/data_structures/findTranslocationsOnTheFly.cpp