### PR TITLE
2.12.0

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -3,6 +3,6 @@ cd build
 cmake ..
 make 
 cd ..
-#pip install numpy cython
+pip install numpy cython
 cd src
 python setup.py build_ext --inplace

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -3,6 +3,6 @@ cd build
 cmake ..
 make 
 cd ..
-pip install numpy cython
+#pip install numpy cython
 cd src
 python setup.py build_ext --inplace

--- a/TIDDIT.py
+++ b/TIDDIT.py
@@ -8,7 +8,7 @@ wd=os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, '{}/src/'.format(wd))
 import TIDDIT_calling
 
-version = "2.11.0"
+version = "2.12.0"
 parser = argparse.ArgumentParser("""TIDDIT-{}""".format(version),add_help=False)
 parser.add_argument('--sv'       , help="call structural variation", required=False, action="store_true")
 parser.add_argument('--cov'        , help="generate a coverage bed file", required=False, action="store_true")

--- a/src/TIDDIT.cpp
+++ b/src/TIDDIT.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
 	int min_variant_size= 100;
 	int sample = 100000000;
 	string outputFileHeader ="output";
-	string version = "2.11.0";
+	string version = "2.12.0";
 	
 	//collect all options as a vector
 	vector<string> arguments(argv, argv + argc);

--- a/src/TIDDIT_calling.py
+++ b/src/TIDDIT_calling.py
@@ -234,9 +234,21 @@ def cluster(args):
 	for chrA in chromosomes:
 		calls[chrA] =[]
 		print ("{}".format(chrA))
-		for chrB in chromosomes:
-			signal_data=numpy.array([ [hit[0],hit[1],hit[2],hit[3],hit[4],hit[5],hit[6],hit[7]] for hit in args.c.execute('SELECT posA,posB,forwardA,qualA,forwardB,qualB,resolution,name FROM TIDDITcall WHERE chrA == \'{}\' AND chrB == \'{}\''.format(chrA,chrB)).fetchall()])
+		signals_chrA={}
+		signals=[ [hit[0],hit[1],hit[2],hit[3],hit[4],hit[5],hit[6],hit[7],hit[8]] for hit in args.c.execute('SELECT chrB,posA,posB,forwardA,qualA,forwardB,qualB,resolution,name FROM TIDDITcall WHERE chrA == \'{}\''.format(chrA)).fetchall()]
 
+		for chrB in chromosomes:
+			if not chrB in signals_chrA:
+				signals_chrA[chrB] = []
+
+		for signal in signals:
+			signals_chrA[signal[0]].append(signal[1:])
+
+		for chrB in signals_chrA:
+			signals_chrA[chrB]=numpy.array(signals_chrA[chrB])
+		
+		for chrB in chromosomes:
+			signal_data=signals_chrA[chrB]
 			if not len(signal_data):
 				continue
 

--- a/src/TIDDIT_coverage.py
+++ b/src/TIDDIT_coverage.py
@@ -88,7 +88,7 @@ def determine_ploidy(args,chromosomes,coverage_data,Ncontent,library_stats):
 			print ("make sure that the contigs of the bam file and the reference match")
 			quit()
 
-	if len(cov):
+	if cov.size:
 		coverage_norm=numpy.median(cov)
 	else:
 		coverage_norm=1
@@ -107,7 +107,11 @@ def determine_ploidy(args,chromosomes,coverage_data,Ncontent,library_stats):
 		else:
 			cov=coverage_data[chromosome][numpy.where( (coverage_data[chromosome][:,1] > args.Q) | (coverage_data[chromosome][:,1] == 0) ),0]
 
-		chromosomal_average=numpy.median(cov)
+		if cov.size:
+			chromosomal_average=numpy.median(cov)
+		else:
+			chromosomal_average=0
+
 		if not args.force_ploidy:
 			try:
 				ploidies[chromosome]=int(round((chromosomal_average)/coverage_norm*args.n))

--- a/versioned_singularity/TIDDIT.2.12.0
+++ b/versioned_singularity/TIDDIT.2.12.0
@@ -1,0 +1,23 @@
+BootStrap: debootstrap
+OSVersion: trusty
+MirrorURL: http://us.archive.ubuntu.com/ubuntu/
+
+
+%runscript
+    echo "This is what happens when you run the container..."
+
+
+%post
+    echo "Hello from inside the container"
+    sed -i 's/$/ universe/' /etc/apt/sources.list
+    apt-get update
+    apt-get -y --force-yes install build-essential cmake make zlib1g-dev python python-dev python-setuptools git wget libbz2-dev unzip
+    easy_install pip
+    pip install numpy cython
+
+    wget https://github.com/SciLifeLab/TIDDIT/archive/TIDDIT-2.12.0.zip
+    unzip TIDDIT-2.12.0.zip
+
+    mv TIDDIT-TIDDIT-2.12.0/* /bin/
+    cd /bin/ && ./INSTALL.sh
+    chmod +x /bin/TIDDIT.py


### PR DESCRIPTION
TIDDIT will now be faster on genomes having a large number of contigs

I have silenced some warning messages appearing on contigs having 0 coverage across every bin