### PR TITLE
Fail if we cannot make output dirs

### DIFF
--- a/tiddit/__main__.py
+++ b/tiddit/__main__.py
@@ -115,11 +115,8 @@ def main():
 			i+=1
 
 		prefix=args.o
-		try:
-			os.mkdir( "{}_tiddit".format(prefix) )
-			os.mkdir("{}_tiddit/clips".format(prefix) )
-		except:
-			print("Folder already exists")
+		os.mkdir(f"{prefix}_tiddit")
+		os.mkdir(f"{prefix}_tiddit/clips")
 
 		pysam.index("-c","-m","6","-@",str(args.threads),bam_file_name,"{}_tiddit/{}.csi".format(args.o,sample_id))
 


### PR DESCRIPTION
👋 Hey, @J35P312. 

This is just a tiny PR to fix an issue that was causing me problems while I was trying to get up and running. I've commented on the change below and in the commit message. 

Let me know if you have questions or thoughts, and how you handle PRs in general. Thanks in advance!

---

Failing to create either of these two dirs should result in an immediate exit, as downstream code assumes that they've been created and will fail ungracefully, with a red-herring error.

Further, there are many reasons why `mkdir` can fail, not just because the "Folder already exists". For example, permissions issues can cause a failure, in which case the printed statement is misleading.