### PR TITLE
GC calculation fix

### DIFF
--- a/tiddit/tiddit_gc.pyx
+++ b/tiddit/tiddit_gc.pyx
@@ -27,9 +27,8 @@ def binned_gc(fasta_path,contig,bin_size,n_cutoff):
 		if n/bin_size > n_cutoff:
 			contig_gc[bin]=-1
 		else:
-			result = round(100*gc/number_of_chars)
-			contig_gc[bin] = result
-			
+			contig_gc[bin] = round(100*gc/number_of_chars)
+
 		next_start+=bin_size
 	return([contig,contig_gc])
 

--- a/tiddit/tiddit_gc.pyx
+++ b/tiddit/tiddit_gc.pyx
@@ -6,30 +6,31 @@ from joblib import Parallel, delayed
 def binned_gc(fasta_path,contig,bin_size,n_cutoff):
 	fasta=pysam.FastaFile(fasta_path)
 	contig_length=fasta.get_reference_length(contig)
-	elements=int(math.ceil(contig_length/bin_size))
+	number_of_bins=int(math.ceil(contig_length/bin_size))
 	
-	contig_gc=numpy.zeros(elements,dtype=numpy.int8)
+	contig_gc=numpy.zeros(number_of_bins,dtype=numpy.int8)
 
-	start=0
-	for i in range(0,elements):
-		slice=fasta.fetch(contig, start, start+bin_size)
+	next_start=0
+	for bin in range(0,number_of_bins):
+		slice=fasta.fetch(contig, next_start, next_start+bin_size)
 		n=0
 		gc=0
+		number_of_chars=0
 
-		for charachter in slice:
-			if charachter == "N" or charachter == "n":
+		for character in slice:
+			number_of_chars += 1
+			if character == "N" or character == "n":
 				n+=1
-			elif charachter == "C" or charachter == "c" or charachter == "G" or charachter == "g":
+			elif character == "C" or character == "c" or character == "G" or character == "g":
 				gc+=1
 
 		if n/bin_size > n_cutoff:
-			contig_gc[i]=-1
-
+			contig_gc[bin]=-1
 		else:
-			contig_gc[i]=round(100*gc/elements)
-
-		start+=bin_size
-
+			result = round(100*gc/number_of_chars)
+			contig_gc[bin] = result
+			
+		next_start+=bin_size
 	return([contig,contig_gc])
 
 def main(reference,contigs,threads,bin_size,n_cutoff):


### PR DESCRIPTION
Hi,
We were hitting issues with GC calculation on our Sarek pipeline.
Values calculated by `round(100*gc/elements)` were higher than signed byte type can hold which was strange given the fact that value should be 100(%) max.
I fixed the issue (division should not have been done by number of bins but by number of characters in a slice).
Additionally I renamed the variables to provide more clarity to the code.