### PR TITLE
Fixed build issues with pip install -e .

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools","pysam","numpy","cython","joblib"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     define_macros=pysam.get_defines(),
     include_dirs=[numpy.get_include()]+pysam.get_include(),
     packages = ['tiddit'],
-    install_requires = ['numpy','pysam'],
+    install_requires = ['numpy','pysam','joblib'],
     entry_points = {'console_scripts': ['tiddit = tiddit.__main__:main']},
 
 )


### PR DESCRIPTION
Running `pip install -e . ` simply didn't work.
There were issues with setup.py failing due to numpy missing despite being already installed in virtual environment.
Adding `pyproject.toml` helped `pip` not only to install all required packages but also make them available in setup.py.

My environment was Ubuntu 24.04, Python 3.12.3 and pip 24.0